### PR TITLE
Add empty string as default value for $string property to avoid issue…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,30 +1,30 @@
 {
-  "name": "chroma-x/string-builder",
-  "type": "library",
-  "description": "A string builder library providing different string methods written in PHP.",
-  "keywords": [
-    "String",
-    "Builder"
-  ],
-  "homepage": "http://chroma-x.de/",
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Martin Brecht-Precht",
-      "email": "mb@chroma-x.de",
-      "homepage": "http://chroma-x.de"
-    }
-  ],
-  "autoload": {
-    "psr-4": {
-      "ChromaX\\StringBuilder\\": "src/"
-    }
-  },
-  "require": {
-    "php": ">=5.4"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "~4.8",
-    "codeclimate/php-test-reporter": "dev-master"
-  }
+	"name": "chroma-x/string-builder",
+	"type": "library",
+	"description": "A string builder library providing different string methods written in PHP.",
+	"keywords": [
+		"String",
+		"Builder"
+	],
+	"homepage": "https://chroma-x.de/",
+	"license": "MIT",
+	"authors": [
+		{
+			"name": "Martin Brecht-Precht",
+			"email": "mb@chroma-x.de",
+			"homepage": "https://chroma-x.de"
+		}
+	],
+	"autoload": {
+		"psr-4": {
+			"ChromaX\\StringBuilder\\": "src/"
+		}
+	},
+	"require": {
+		"php": ">=5.4"
+	},
+	"require-dev": {
+		"phpunit/phpunit": "~4.8",
+		"codeclimate/php-test-reporter": "dev-master"
+	}
 }

--- a/src/StringBuilder.php
+++ b/src/StringBuilder.php
@@ -16,7 +16,7 @@ class StringBuilder
 	/**
 	 * @var string
 	 */
-	private $string;
+	private $string = '';
 
 	/**
 	 * SimpleStringBuilder constructor


### PR DESCRIPTION
I added a default value of empty string to avoid null-related errors, while the $string property is not always initialized in the constructor. 

This problem mainly occurs in PHP > 8, where it throws fatal errors in functions like strlen() or mb_strlen().